### PR TITLE
make ping path configurable

### DIFF
--- a/local.cfg
+++ b/local.cfg
@@ -26,3 +26,4 @@ http_address = "0.0.0.0:4180"
 skip_provider_button  = true
 allowed_origin = "http://localhost:3000"
 skip_auth_preflight = true
+ping_path = "/"

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func main() {
 	config := flagSet.String("config", "", "path to config file")
 	showVersion := flagSet.Bool("version", false, "print version string")
 
+	flagSet.String("ping-path", "/ping", "ping path")
 	flagSet.String("allowed-origin", "localhost:3000", "allowed origin for cors requests with credentials")
 	flagSet.String("http-address", "127.0.0.1:4180", "[http://]<addr>:<port> or unix://<path> to listen on for HTTP clients")
 	flagSet.String("https-address", ":443", "<addr>:<port> to listen on for HTTPS clients")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -240,7 +240,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		Validator:      validator,
 
 		RobotsPath:        "/robots.txt",
-		PingPath:          "/ping",
+		PingPath:          opts.PingPath,
 		SignInPath:        fmt.Sprintf("%s/sign_in", opts.ProxyPrefix),
 		SignOutPath:       fmt.Sprintf("%s/sign_out", opts.ProxyPrefix),
 		OAuthStartPath:    fmt.Sprintf("%s/start", opts.ProxyPrefix),

--- a/options.go
+++ b/options.go
@@ -28,6 +28,7 @@ type Options struct {
 	AllowedOrigin   string `flag:"allowed-origin" cfg:"allowed_origin" env:"OAUTH2_PROXY_ALLOWED_ORIGIN"`
 	SupressWarnings bool   `flag:"supress-warnings" cfg:"supress_warnings" env:"OAUTH2_PROXY_SUPRESS_WARNINGS"`
 
+	PingPath        string `flag:"ping-path" cfg:"ping_path" env:"PING_PATH"`
 	ProxyPrefix     string `flag:"proxy-prefix" cfg:"proxy_prefix" env:"OAUTH2_PROXY_PROXY_PREFIX"`
 	ProxyWebSockets bool   `flag:"proxy-websockets" cfg:"proxy_websockets" env:"OAUTH2_PROXY_PROXY_WEBSOCKETS"`
 	HTTPAddress     string `flag:"http-address" cfg:"http_address" env:"OAUTH2_PROXY_HTTP_ADDRESS"`
@@ -163,6 +164,7 @@ func NewOptions() *Options {
 		AuthLogging:           true,
 		AuthLoggingFormat:     logger.DefaultAuthLoggingFormat,
 		SupressWarnings:       false,
+		PingPath:              "/ping",
 	}
 }
 

--- a/test.cfg
+++ b/test.cfg
@@ -22,3 +22,4 @@ email_domains = [
 
 skip_provider_button  = true
 http_address = "0.0.0.0:4180"
+ping_path = "/"

--- a/uat.cfg
+++ b/uat.cfg
@@ -33,3 +33,4 @@ skip_provider_button  = true
 allowed_origin = "https://landx.uat.cbre.co.uk"
 skip_auth_preflight = true
 supress_warnings = true
+ping_path = "/"


### PR DESCRIPTION
change the ping path from "/ping" to "/" to avoid "Error loading cookied session: Cookie "_oauth2_proxy" not present" being raised from MS Azure http polls. 